### PR TITLE
Create env as early as possible

### DIFF
--- a/src/main/kotlin/com/github/otkmnb2783/dotenv/GradleDotenvPlugin.kt
+++ b/src/main/kotlin/com/github/otkmnb2783/dotenv/GradleDotenvPlugin.kt
@@ -12,6 +12,10 @@ class GradleDotenvPlugin: Plugin<Project> {
     override fun apply(project: Project) {
         logger.debug("gradle dotenv plugin applying")
         project.extensions.create("dotenv", GradleDotenvConfiguration::class.java)
+
+        val env = mutableMapOf<String, String>()
+        project.extensions.add("env", env)
+
         project.run {
             logger.debug("gradle dotenv plugin running.")
             val configuration = this.extensions.findByName("dotenv") as GradleDotenvConfiguration
@@ -22,16 +26,15 @@ class GradleDotenvPlugin: Plugin<Project> {
             logger.debug("loaded configuration dir:={}", dir)
             logger.debug("loaded configuration fileName:={}", configuration.fileName)
             logger.debug("dotenv file path:={}", f)
+
             if (!f.exists()) {
                 logger.warn("dotenv file is not found.")
                 return@run
             }
-            val env = mutableMapOf<String, String>()
             f.forEachLine {
                 logger.debug("line is:={}", it)
-                if (it.isWhitespace() and it.isComment()) {
-                    logger.debug("it is whitespace or comment line.")
-                    logger.debug("it is skipping.")
+                if (it.ifBlank{"#"}.trim().isComment()) {
+                    logger.debug("skipping whitespace or comment line.")
                     return@forEachLine
                 }
                 val matcher = it.parse() ?: return@forEachLine
@@ -40,7 +43,6 @@ class GradleDotenvPlugin: Plugin<Project> {
                 env[key] = value.normalized()
             }
             logger.debug("dotenv file is loaded. env:={}", env)
-            project.extensions.add("env", env)
             logger.info("dotenv file is loaded.")
         }
         logger.debug("gradle dotenv plugin applied.")


### PR DESCRIPTION
It will be good if the `env` extension is created as soon as the plugin is applied, rather than after checking if an environment file exists. It can remain empty after creation. I think this is a good default behaviour.

Also fixed checking for whitespace or comment lines: Previous version was checking if a line was both whitespace **and** comment, instead of using the disjunction.